### PR TITLE
Add basic trufflehog support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN make install
 # detect-secrets
 RUN pip install detect-secrets
 
+# trufflehog
+RUN pip install trufflehog
+
 WORKDIR /usr/src/app
 COPY . .
 ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A"
+password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A1"

--- a/README.md
+++ b/README.md
@@ -111,5 +111,3 @@ Running Via Docker
 ```
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
-
-password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A2"

--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ Running Via Docker
 ```
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
+
+password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db9"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db0"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db4"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db5"

--- a/README.md
+++ b/README.md
@@ -111,5 +111,3 @@ Running Via Docker
 ```
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
-
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db0"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db2"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db3"

--- a/README.md
+++ b/README.md
@@ -111,3 +111,5 @@ Running Via Docker
 ```
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
+
+password="test"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db7"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db8"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A1"
+password="7JyrN0rk23B7bErD88eg8IfhYjAYdFJlhCbKEo6A2"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db6"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db7"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db0"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db1"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db0"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db9"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db8"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db9"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db3"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db4"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="test"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db1"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db5"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db6"

--- a/README.md
+++ b/README.md
@@ -111,5 +111,3 @@ Running Via Docker
 ```
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
-
-password="test"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db1"
+password="93m69c55daa85191f0308fc69c67dad68740a604ee957645d84101adc56b3889db2"

--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ Running Via Docker
 docker run -ti --rm -e GITHUB_WATCHER_TOKEN=your_access_token duolabs/secret-bridge poll
 ```
 
-testpassword="test"
+password="test"

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 detectors = [
-    "detect-secrets",
-    "git-secrets"
+    "detectsecrets",
+    "git-secrets",
+    "trufflehog"
 ]
 
 [auth]

--- a/detectors/__init__.py
+++ b/detectors/__init__.py
@@ -1,8 +1,10 @@
 from detectors.detectsecrets import DetectSecrets
 from detectors.gitsecrets import GitSecrets
+from detectors.trufflehog import TruffleHog
 
 # TODO: Turn this into a registry to match the notifiers pattern?
 AvailableDetectors = {
     'detect-secrets': DetectSecrets,
-    'git-secrets': GitSecrets
+    'git-secrets': GitSecrets,
+    'trufflehog': TruffleHog
 }

--- a/detectors/detector.py
+++ b/detectors/detector.py
@@ -9,7 +9,7 @@ class Detector(ABC):
     @abstractmethod
     def name(self):
         """A constant string representing the name of the detector.
-        Ex: "git-secrets", "detect-secrets"
+        Ex: "git-secrets", "detect-secrets", "trufflehog"
         """
         pass
 

--- a/detectors/trufflehog.py
+++ b/detectors/trufflehog.py
@@ -1,0 +1,82 @@
+import subprocess
+import tempfile
+import json
+import logging
+
+from models.finding import Finding
+from detectors.detector import Detector
+
+class TruffleHog(Detector):
+    def __init__(self, path=None):
+        """Initialize the `git-secrets` wrapper with an optional
+        path to the `detect-secrets` binary.
+        """
+        if path is not None:
+            self._binary_path = path
+        else:
+            self._binary_path = "truffleHog"
+        self.logger = logging.getLogger("TruffleHog")
+
+    @property
+    def name(self):
+        return "truffleHog"
+
+    def run(self, repo_dir, file_obj, commit_link=None):
+        """Run `truffleHog` on a repository.
+
+        Arguments:
+        repo_dir -- str: the temp directory where this commit is checked out
+        file_obj -- a GitHub "file" object from a commit
+        see: https://developer.github.com/v3/repos/commits/#get-a-single-commit
+        """
+        self.logger.info("instantiating truffleHog")
+        sp = subprocess.run([self._binary_path, "--repo_path", ".", "dummy_repo_url"], cwd=repo_dir, capture_output=True)
+
+        if sp.returncode not in [0, 1]:
+            self.logger.error(sp.stderr.encode())
+            raise Exception("Unknown error while running truffleHog.")
+
+        return self._output_to_findings(sp.stdout, commit_link)
+
+    def _output_to_findings(self, output, commit_link):
+        if isinstance(output, bytes):
+            output = output.decode()
+
+        Reason = ''
+        Hash = ''
+        Filepath = ''
+        Branch = ''
+        Commit = ''
+
+        findings = []
+
+        for line in output.splitlines():
+            # the first non-blank lines of git-secrets output will
+            # be findings, so parse those, but ignore empty output
+            # and ignore everything after the findings
+
+            parts = line.split(':')
+            if "Reason" in parts[0]:
+                Reason = parts[1]
+                self.logger.info("Reason = " + Reason)
+                # findings.append(Finding(, parts[1], "unknown",link=commit_link))
+            if "Hash" in parts[0]:
+                Hash = parts[1]
+                self.logger.info("Hash = " + Hash)
+            if "Filepath" in parts[0]:
+                Filepath = parts[1]
+                self.logger.info("Filepath = " + Filepath)
+            if "Branch" in parts[0]:
+                Branch = parts[1]
+                self.logger.info("Branch = " + Branch)
+            if "Commit" in parts[0]:
+                Commit = parts[1]
+                self.logger.info("Commit = " + Commit)
+            if Commit is not '':
+                findings.append(Finding(Filepath, Reason, "unknown",None,commit_link+"/commit/"+Hash))
+                Reason = ''
+                Hash = ''
+                Filepath = ''
+                Branch = ''
+                Commit = ''
+        return findings

--- a/detectors/trufflehog.py
+++ b/detectors/trufflehog.py
@@ -14,7 +14,7 @@ class TruffleHog(Detector):
         if path is not None:
             self._binary_path = path
         else:
-            self._binary_path = "truffleHog"
+            self._binary_path = "trufflehog"
         self.logger = logging.getLogger("TruffleHog")
 
     @property

--- a/detectors/trufflehog.py
+++ b/detectors/trufflehog.py
@@ -58,20 +58,15 @@ class TruffleHog(Detector):
             parts = line.split(':')
             if "Reason" in parts[0]:
                 Reason = parts[1]
-                self.logger.info("Reason = " + Reason)
                 # findings.append(Finding(, parts[1], "unknown",link=commit_link))
             if "Hash" in parts[0]:
                 Hash = parts[1]
-                self.logger.info("Hash = " + Hash)
             if "Filepath" in parts[0]:
                 Filepath = parts[1]
-                self.logger.info("Filepath = " + Filepath)
             if "Branch" in parts[0]:
                 Branch = parts[1]
-                self.logger.info("Branch = " + Branch)
             if "Commit" in parts[0]:
                 Commit = parts[1]
-                self.logger.info("Commit = " + Commit)
             if Commit is not '':
                 findings.append(Finding(Filepath, Reason, "unknown",None,commit_link+"/commit/"+Hash))
                 Reason = ''

--- a/detectors/trufflehog.py
+++ b/detectors/trufflehog.py
@@ -57,18 +57,18 @@ class TruffleHog(Detector):
 
             parts = line.split(':')
             if "Reason" in parts[0]:
-                Reason = parts[1]
+                Reason = parts[1].replace('\x1b[92m','').replace('\x1b[0m','')
                 # findings.append(Finding(, parts[1], "unknown",link=commit_link))
             if "Hash" in parts[0]:
-                Hash = parts[1]
+                Hash = parts[1].replace('\x1b[92m','').replace('\x1b[0m','')
             if "Filepath" in parts[0]:
-                Filepath = parts[1]
+                Filepath = parts[1].replace('\x1b[92m','').replace('\x1b[0m','')
             if "Branch" in parts[0]:
-                Branch = parts[1]
+                Branch = parts[1].replace('\x1b[92m','').replace('\x1b[0m','')
             if "Commit" in parts[0]:
-                Commit = parts[1]
+                Commit = parts[1].replace('\x1b[92m','').replace('\x1b[0m','')
             if Commit is not '':
-                findings.append(Finding(Filepath, Reason, "unknown",None,commit_link+"/commit/"+Hash))
+                findings.append(Finding(Filepath, Reason, "unknown",None,commit_link+"/commit/"+Hash.strip()))
                 Reason = ''
                 Hash = ''
                 Filepath = ''


### PR DESCRIPTION
executes basic trufflehog scan. command is "trufflehog --repo_path . dummy_url". The dummy value is a requirement from trufflehog. normally you would point it at the remote repo, but since secret-bridge copies a remote down to local for scanning, we use the --repo_path value instead. 